### PR TITLE
fix(resize-multiple): add checkReply in case of exception

### DIFF
--- a/src/main/java/fr/wseduc/resizer/ImageResizer.java
+++ b/src/main/java/fr/wseduc/resizer/ImageResizer.java
@@ -330,6 +330,7 @@ public class ImageResizer extends BusModBase implements Handler<Message<JsonObje
 						});
 					} catch (IOException e) {
 						logger.error("Error processing image.", e);
+						checkReply(m, count, results);
 					}
 				}
 			}


### PR DESCRIPTION
## Description

Quand nous utilisons les endpoints `${host}/workspace/document/${documentId}?thumbnail=120x120` nous avons quelques erreurs au niveau de la persistance des images : 

```
SEVERE Error processing image.
javax.imageio.IIOException: Invalid argument to native writeImage
	at com.sun.imageio.plugins.jpeg.JPEGImageWriter.writeImage(Native Method)
	at com.sun.imageio.plugins.jpeg.JPEGImageWriter.writeOnThread(JPEGImageWriter.java:1067)
	at com.sun.imageio.plugins.jpeg.JPEGImageWriter.write(JPEGImageWriter.java:363)
	at fr.wseduc.resizer.ImageResizer.compressImage(ImageResizer.java:541)
	at fr.wseduc.resizer.ImageResizer.persistImage(ImageResizer.java:435)
	at fr.wseduc.resizer.ImageResizer.access$2400(ImageResizer.java:55)
	at fr.wseduc.resizer.ImageResizer$5.handle(ImageResizer.java:320)
	at fr.wseduc.resizer.ImageResizer$5.handle(ImageResizer.java:281)
	at fr.wseduc.resizer.FileSystemFileAccess$1.handle(FileSystemFileAccess.java:66)
	at fr.wseduc.resizer.FileSystemFileAccess$1.handle(FileSystemFileAccess.java:62)
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:327)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.WorkerContext.lambda$wrapTask$0(WorkerContext.java:35)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
```

Puis survient quelques secondes plus tard : 

```
...

SEVERE java.lang.RuntimeException: Failed to send a request to the image resizer
```

L'exception est catché mais la conséquence est que sans réponse de la part de `mod-image-resize`, la réponse se fait tardivement côté entcore comme il reçoit bien plus tard l'exception (cf [code ici ](https://github.com/opendigitaleducation/entcore/blob/master/common/src/main/java/org/entcore/common/folders/impl/FolderManagerMongoImpl.java#L1027)) donc ça créer quelques lenteurs quand on a une liste avec des images

## Test

Nous avons pu voir la différence avec ce commit en terme de "rapidité" sur nos plateformes

Sans ce commit : Quand on requête  `${host}/workspace/document/${documentId}?thumbnail=120x120` la réponse arrive plus tard (cf comportement log au-dessus)

Avec ce commit, le log exception + log de l'entcore arrive rapidement